### PR TITLE
Fix docker-compose env variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,13 +1,17 @@
+# PostgreSQL settings
 POSTGRES_DB=faydakyc
 POSTGRES_USER=faydakycuser
 POSTGRES_PASSWORD=supersecretpassword
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
 
+# Django settings
 DJANGO_SECRET_KEY=your-very-secret-key
 DJANGO_DEBUG=True
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
-POSTGRES_HOST=db
-POSTGRES_PORT=5432
 JWT_SECRET_KEY=changeme
+
+# Third-party services
 STRIPE_API_KEY=
 STRIPE_WEBHOOK_SECRET=
 CHAPA_API_KEY=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000/api/


### PR DESCRIPTION
## Summary
- add missing env example files
- update backend `.env` with POSTGRES host configuration

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings pytest -q` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_6841e73abaf08320ba288f6acd92b81f